### PR TITLE
fix: When no data element filter was used, URLs could be too large

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datim-narratives-app
 Type: Shiny App
 Title: Self-service app for analyzing narrative data
-Version: 0.0.7
-Date: 2024-02-09
+Version: 0.0.8
+Date: 2024-03-15
 Authors@R: c( person("Jason", "Pickering", email =
         "jason@dhis2.org", role = c("aut", "cre"))
 Depends: R (>= 4.2.1)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datim-narratives-app
 Type: Shiny App
 Title: Self-service app for analyzing narrative data
-Version: 0.0.8
-Date: 2024-03-15
+Version: 0.0.9
+Date: 2024-11-14
 Authors@R: c( person("Jason", "Pickering", email =
         "jason@dhis2.org", role = c("aut", "cre"))
 Depends: R (>= 4.2.1)

--- a/partner_narratives_template.Rmd
+++ b/partner_narratives_template.Rmd
@@ -77,7 +77,7 @@ cat('\n\n')
 
 country_data<-partner_data %>% 
     dplyr::filter(country == unique_countries[x]) %>% 
-    dplyr::arrange(agency_name,mech_code,`Data`)
+    dplyr::arrange(agency_name,mech_code,technical_area,support_type)
   
 unique_mechs<-unique(sort(country_data$mech_code))
 
@@ -104,7 +104,7 @@ for ( y in seq_along(unique_mechs)) {
 
 mech_data<-country_data %>%  
   dplyr::filter(mech_code == unique_mechs[y]) %>%
-  dplyr::arrange(partner_name,mech_code,`Data`)
+  dplyr::arrange(partner_name,mech_code,technical_area, support_type)
   
 cat(paste0("### Mechanism: ",mech_data$mech_name[1]))
 cat('\n\n')

--- a/server.R
+++ b/server.R
@@ -537,13 +537,20 @@ shinyServer(function(input, output, session) {
         
       get_des<- function()
         {
-            if ( is.null(input$des )) {return(user_input$partner_data_elements$de_uid)} else {
-              user_input$partner_data_elements %>% 
-                dplyr::filter(technical_area %in% input$des) %>% 
-                dplyr::filter(year = user_input$fiscal_year) %>% 
-                dplyr::pull(de_uid) %>% 
-                unique(.)
-            } }
+        if (is.null(input$des)) {
+          return(
+            user_input$partner_data_elements %>%
+              dplyr::filter(year == user_input$fiscal_year) %>%
+                              dplyr::pull(de_uid) %>%
+                              unique(.)
+          )
+        } else {
+          user_input$partner_data_elements %>%
+            dplyr::filter(technical_area %in% input$des) %>%
+            dplyr::filter(year = user_input$fiscal_year) %>%
+            dplyr::pull(de_uid) %>%
+            unique(.)
+        } }
         
       all_des <- get_des()
       d<-list()
@@ -554,8 +561,9 @@ shinyServer(function(input, output, session) {
                                          all_des = all_des,
                                          d2_session = user_input$d2_session)
 
-  
-      d$partner <- d2_analyticsResponse(url, remapCols = FALSE,d2_session = user_input$d2_session)
+      browser()
+      d$partner <- d2_analyticsResponse(url, remapCols = FALSE,
+                                        d2_session = user_input$d2_session)
     
       if (user_input$is_usg_user  & input$includeUSGNarratives ) {
         url<- assembleUSGNarrativeURL(ou = countries,

--- a/utils.R
+++ b/utils.R
@@ -257,12 +257,11 @@ assemblePartnerNarrativeURL<-function(ou,fiscal_year,fiscal_quarter,all_des, d2_
   
   this_period<-convertFYQuarterCalendarQuarter(fiscal_year, fiscal_quarter )
   base_url<-paste0(d2_session$base_url,"api/analytics?")
-  
   mechanisms_bit<-paste0("dimension=SH885jaRe0o")
 
   period_bit<-paste0("&filter=pe:", this_period)
-  de_bit<-paste0("&dimension=dx:",paste(all_des,sep="",collapse=";"))
-  ou_bit<-paste0("&dimension=ou:", paste(ou,sep="",collapse=";"))
+  de_bit<-paste0("&dimension=dx:",paste(unique(all_des),sep="",collapse=";"))
+  ou_bit<-paste0("&dimension=ou:", paste(unique(ou),sep="",collapse=";"))
   end_bit<-"&displayProperty=SHORTNAME&skipData=false&includeMetadataDetails=false&outputIdScheme=uid"
   
   url <-paste0(base_url,mechanisms_bit,de_bit,ou_bit,period_bit,end_bit)


### PR DESCRIPTION
The list of data elements was not being filtered by fiscal year selected, which resulted in potentially very large URLs when no data elements were selected as a filter. 